### PR TITLE
Nsullivan tz

### DIFF
--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -2784,8 +2784,8 @@ static int Pkcs11ECDH(Pkcs11Session* session, wc_CryptoInfo* info)
                                                           info->pk.ecdh.outlen);
     }
 
-    if (sessionKey)
-        session->func->C_DestroyObject(session->handle, privateKey);
+    session->func->C_DestroyObject(session->handle, privateKey);
+    session->func->C_DestroyObject(session->handle, secret);
 
     if (point != NULL)
         XFREE(point, info->pk.ecdh.public_key->heap, DYNAMIC_TYPE_ECC_BUFFER);

--- a/wolfcrypt/src/wc_pkcs11.c
+++ b/wolfcrypt/src/wc_pkcs11.c
@@ -627,7 +627,8 @@ static int Pkcs11Token_Init(Pkcs11Token* token, Pkcs11Dev* dev, int slotId,
         token->userPinLogin = 0;
     }
 
-    XFREE(slot, dev->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (slot != NULL)
+        XFREE(slot, dev->heap, DYNAMIC_TYPE_TMP_BUFFER);
 
     return ret;
 }


### PR DESCRIPTION
Small bug fixes found when using PKCS11 to call functions in wolfBoot via TrustZone nonsecure calls.